### PR TITLE
Remove webpack as a dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,6 @@ PATH
   specs:
     rails_pages (0.1.0)
       rails (>= 6.0)
-      webpacker (~> 5.2.1)
 
 GEM
   remote: https://rubygems.org/

--- a/rails_pages.gemspec
+++ b/rails_pages.gemspec
@@ -42,5 +42,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'rails', '>= 6.0'
-  spec.add_dependency 'webpacker', '~> 5.2.1'
+  spec.add_development_dependency 'webpacker', '~> 5.2.1'
 end


### PR DESCRIPTION
## Context

Webpack is actually not required for Rails pages.

This pull request removes it as a hard dependency.