### PR TITLE
Silently fail when CSRF meta tags do not exist

### DIFF
--- a/js/index.ts
+++ b/js/index.ts
@@ -117,20 +117,16 @@ export async function post(
   params: Object
 ): Promise<Object> {
   // Rails generates meta tags with anti-CSRF information.
+  // These tags may not exist when CSRF is disabled.
   const csrfParamMeta = document.getElementsByName('csrf-param')[0];
   const csrfTokenMeta = document.getElementsByName('csrf-token')[0];
 
-  if (!(csrfParamMeta instanceof HTMLMetaElement)) {
-    console.error(csrfParamMeta);
-    throw 'CSRF param unspecified';
+  if ((csrfParamMeta instanceof HTMLMetaElement) && (csrfTokenMeta instanceof HTMLMetaElement)) {
+    // Add the anti-CSRF token to our query.
+    params[csrfParamMeta.content] = csrfTokenMeta.content;
+  } else {
+    console.warn('CSRF token meta tags not found');
   }
-  if (!(csrfTokenMeta instanceof HTMLMetaElement)) {
-    console.error(csrfTokenMeta);
-    throw 'CSRF param unspecified';
-  }
-
-  // Add the anti-CSRF token to our query.
-  params[csrfParamMeta.content] = csrfTokenMeta.content;
 
   // Make a POST to the action endpoint with the query as JSON.
   const response = await fetch(`${location.pathname}/action/${action}`, {


### PR DESCRIPTION
This PR updates `post` function to continues to work when Rails' CSRF `<meta>` tags are missing.

I noticed in the feature spec in the test environment that any interactions that calls `post()` function would fail with an error message because Rails disables CSRF protection [by default](https://github.com/rails/rails/blob/488a7ce188803828c3e7111e23e70108d761c283/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt#L33-L34) in the test environment.

This update will allow us to be able to run feature test on the pages that uses `post()` function to updates the backend.