### PR TITLE
Add Optional headers Param to post

### DIFF
--- a/js/index.ts
+++ b/js/index.ts
@@ -114,7 +114,8 @@ export async function get(
 //
 export async function post(
   action: string,
-  params: Object
+  params: Object,
+  headers?: Record<string, string>
 ): Promise<Object> {
   // Rails generates meta tags with anti-CSRF information.
   const csrfParamMeta = document.getElementsByName('csrf-param')[0];
@@ -140,7 +141,8 @@ export async function post(
     credentials: 'same-origin',
     headers: {
       'Content-Type': 'application/json',
-      Accept: 'application/json'
+      Accept: 'application/json',
+      ...headers
     },
     body: JSON.stringify(params)
   });

--- a/js/package.json
+++ b/js/package.json
@@ -1,26 +1,26 @@
 {
-  "name": "rails-pages",
-  "version": "0.2.0",
-  "description": "The JS half of the rails_pages ruby gem",
-  "main": "index.js",
-  "types": "index.d.ts",
-  "scripts": {
-    "build": "tsc"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/degica/rails_pages.git"
-  },
-  "author": "Nigel Baillie <nigelbaillie@hey.com>",
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/degica/rails_pages/issues"
-  },
-  "homepage": "https://github.com/degica/rails_pages#readme",
-  "devDependencies": {
-    "typescript": "^5.7.3"
-  },
-  "dependencies": {
-    "vue": "^3.1.0"
-  }
+	"name": "rails-pages",
+	"version": "0.3.0",
+	"description": "The JS half of the rails_pages ruby gem",
+	"main": "index.js",
+	"types": "index.d.ts",
+	"scripts": {
+		"build": "tsc"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/degica/rails_pages.git"
+	},
+	"author": "Nigel Baillie <nigelbaillie@hey.com>",
+	"license": "MIT",
+	"bugs": {
+		"url": "https://github.com/degica/rails_pages/issues"
+	},
+	"homepage": "https://github.com/degica/rails_pages#readme",
+	"devDependencies": {
+		"typescript": "^5.7.3"
+	},
+	"dependencies": {
+		"vue": "^3.1.0"
+	}
 }


### PR DESCRIPTION
Allows callers to pass custom request headers when using the post helper. The provided headers are spread after the defaults (Content-Type and Accept), so they can supplement or override the defaults as needed. The parameter is optional, so all existing call sites remain unaffected.